### PR TITLE
fix an issue of nfa_set_nega_char(pair_out) that the '^' sign was not excluded

### DIFF
--- a/nfa/construction.py
+++ b/nfa/construction.py
@@ -95,6 +95,7 @@ def nfa_set_nega_char(pair_out):
     lexer.advance()
     if lexer.match(Token.AT_BOL):
         neagtion = True
+        lexer.advance()
     
     start = pair_out.start_node = Nfa()
     start.next_1 = pair_out.end_node = Nfa()

--- a/test.py
+++ b/test.py
@@ -16,6 +16,7 @@ testLists.append(RegexMaterial("THISISREGEXTEST", "([A-Z]*|[0-9]+)", True))
 testLists.append(RegexMaterial("abbbbb", "[^c]+", True))
 testLists.append(RegexMaterial("ccccc", "[^c]+", False))
 testLists.append(RegexMaterial("123", "[1-3]+", True))
+testLists.append(RegexMaterial("\\^abcde", "[^0-9]+", True))
 
 class TestRegex(unittest.TestCase):
     def test(self):


### PR DESCRIPTION
fix an issue of nfa_set_nega_char(pair_out) that the '^' sign was not exculded